### PR TITLE
Remove dependency to json gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -477,7 +477,6 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-tmpl-rails (1.1.0)
       rails (>= 3.1.0)
-    json (2.5.1)
     jwt (2.2.3)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)


### PR DESCRIPTION
Remove unnecessary dependency to `json` gem which was replated by `multi-json` but not cleaned from last merge between master and https://github.com/CodiTramuntana/decidim-sitges-app/pull/38.